### PR TITLE
Add anon stats on played words

### DIFF
--- a/src/components/Game.vue
+++ b/src/components/Game.vue
@@ -322,6 +322,13 @@ export default {
         this.getWordOfTheDay();
         this.getSavedData();
 
+        if (localStorage.getItem('tokenUUID')) {
+            this.tokenUUID = localStorage.getItem('tokenUUID')
+        } else {
+            this.tokenUUID = new Array(2).fill().map(() => Math.floor(Math.random() * (2**32)).toString(16)).join('-')
+            localStorage.setItem('tokenUUID', this.tokenUUID)
+        }
+
         if (localStorage.getItem('colorBlindMode')) {
             this.colorBlindMode = JSON.parse(localStorage.getItem('colorBlindMode'));
         }
@@ -498,6 +505,20 @@ export default {
             localStorage.setItem('currentAttempt', JSON.stringify(this.currentAttempt));
             localStorage.setItem('won', JSON.stringify(this.won));
             localStorage.setItem('finished', JSON.stringify(this.finished));
+
+            // Stats anonymes des mots joués :
+            let xhr = new XMLHttpRequest;
+            xhr.open('POST', 'https://wordle.xi.richie.fr/play_word');
+            xhr.setRequestHeader("Content-Type", "application/json;charset=UTF-8");
+            xhr.send(JSON.stringify({
+                tokenUUID: this.tokenUUID,
+                buildId: process.env.VUE_APP_BUILD_ID,
+                wordId: this.getWordID(),
+                lineNum: this.currentAttempt - (this.won ? 0 : 1),
+                won: this.won,
+                played: attempt.join(''),
+                result: currentResult.map(e => ['incorrect', 'partial', 'correct'].indexOf(e)).join('')
+            }))
         },
         getStats() {
             if(!this.userResults.games.find((game) => {


### PR DESCRIPTION
_(édit du 20 janvier 2022, la description était initialement vide, cf. diff)_

À celles & ceux qui lisent ces lignes : après m'être concerté avec Louan, je me suis permis de faire un POC où il était question de pourvoir envoyer à un backend tous les mots joués, avec le résultat obtenu, ainsi qu'un token aléatoirement généré & stocké dans le localStorage du client.

L'idée plaisait à Louan, mais il ne souhaitait pas qu'un backend soit ajouté juste pour cette raison seule, un argument que je comprends totalement.

Je reste encore convaincu qu'il aurait pu être à la fois intéressant (statistiquement parlant) & innocent d'aller jusqu'au bout et de merger, mais je respecterai toujours l'avis final de Louan puisqu'il s'agit de son projet, et de sa crédibilité si jamais cela venait à faire l'objet d'une controverse.

Si la PR avait finie par être mergée, j'aurais évidemment publié le code source du backend pour que vous puissiez (par exemple, entre autres) vous assurer que l'adresse IP n'était stockée à aucun moment (bien que cela ne puisse malheureusement jamais constituer une preuve en soi).

Si vous pensez avoir des arguments ou des choses intéressantes à dire sur le sujet, vous êtes les bienvenus pour rouvrir cette PR, ou bien créer une issue qui la mentionnerait.