### PR TITLE
Changement du lien lors du partage

### DIFF
--- a/src/components/Game.vue
+++ b/src/components/Game.vue
@@ -729,7 +729,7 @@ export default {
                     }
                 }).join('');
             }).join('\n');
-            const url = "wordle.louan.me";
+            const url = "https://wordle.louan.me";
 
             let sharedContent = title + schema;
 


### PR DESCRIPTION
Ajout de https:// avant wordle.louan.me afin que les gens à qui l'on partage puissent cliquer sur le lien