### PR TITLE
Fait marcher le bouton Partager sur les vieux navigateurs

### DIFF
--- a/src/components/Game.vue
+++ b/src/components/Game.vue
@@ -224,6 +224,7 @@
                             <div v-if="womenRightsDay" class="special-logo">
                                 <a href="https://www.lesinternettes.com/" target="_blank"><img src="/img/les-internettes-logo.png" alt="Les Internettes" /></a>
                             </div>
+                          <textarea id="clipboard-buffer"></textarea>
                         </div>
                     </div>
                     <div class="modal-footer" v-if="finished && !archivesMode">
@@ -788,24 +789,40 @@ export default {
             }
             
             const errMsg = "Votre navigateur ne permet pas de copier du texte via un bouton. Une solution alternative sera proposée dans une prochaine mise à jour."
-            if (!navigator.clipboard || typeof navigator.clipboard.writeText !== 'function') {
+            if (navigator.clipboard && typeof navigator.clipboard.writeText === 'function') {
+                navigator.clipboard.writeText(sharedContent).then(() => this.changeCopiedStatus()).catch(() => alert(errMsg));
+            } else if (typeof document.execCommand === 'function') {
+                var clipboardBuffer = document.getElementById('clipboard-buffer')
+                clipboardBuffer.value = sharedContent
+                clipboardBuffer.style.display='block'
+                clipboardBuffer.focus()
+                clipboardBuffer.setSelectionRange(0, sharedContent.length); // select() does not work on old browsers (Safari/Firefox on iPhone 6 for instance)
+                document.execCommand("copy");
+                clipboardBuffer.style.display='none'
+                clipboardBuffer.blur();
+                clipboardBuffer.value = ''
+                this.changeCopiedStatus()
+            } else {
                 alert(errMsg);
-                return;
             }
-
-            navigator.clipboard.writeText(sharedContent).then(() => {
-                this.resultsCopied = true;
-                setTimeout(() => (this.resultsCopied = false), 10000);
-            }).catch(() => alert(errMsg));
         },
         formatDate(date) {
             return moment(date).format('DD/MM/YYYY');
         },
+        changeCopiedStatus() {
+            this.resultsCopied = true;
+            setTimeout(() => (this.resultsCopied = false), 10000);
+        }
     }
 }
 </script>
 
 <style lang="sass" scoped>
+#clipboard-buffer
+  display: none
+  width: 150px
+  height: 40px
+
 #game
     display: flex
     align-items: center


### PR DESCRIPTION
Bonjour,

La fonction Partager ne marchait pas sur Firefox/Safari sur iPhone 6.

Pour les navigateurs ne supportant pas `navigator.clipboard` on peut feinter.
Il faut mettre le texte à copier dans un `textarea` (initialiement caché), rendre visible temporairement le `textarea` pour que la copie se fasse puis utiliser `document.execCommand` (déprécié, certes, mais fonctionnel).

J'ai aussi dû utiliser `setSelectionRange()` car `select()` ne fonctionnait pas (cf doc https://developer.mozilla.org/en-US/docs/Web/API/HTMLInputElement/select#notes)

Ça fonctionne bien sur Firefox/Safari sur iPhone 6 et c'est toujours bon sur Firefox 97.0.2 et Chrome 98.0.4758.102 qui eux ont bien `navigator.clipboard`.

Merci !