### PR TITLE
Ajoute bépo aux dispositions de clavier

### DIFF
--- a/src/components/Game.vue
+++ b/src/components/Game.vue
@@ -238,8 +238,9 @@
                             </div>
                             <div class="settings-item setting-button">
                                 <h3>Clavier</h3>
-                                <div class="buttons">
+                                <div class="buttons keyboard-buttons">
                                     <button :class="{ selected: keyboard.name === KEYBOARD_AZERTY.name }" @click="keyboard = KEYBOARD_AZERTY">AZERTY</button>
+                                    <button :class="{ selected: keyboard.name === KEYBOARD_BEPO.name }" @click="keyboard = KEYBOARD_BEPO">BÉPO</button>
                                     <button :class="{ selected: keyboard.name === KEYBOARD_QWERTY.name }" @click="keyboard = KEYBOARD_QWERTY">QWERTY</button>
                                     <button :class="{ selected: keyboard.name === KEYBOARD_QWERTZ.name }" @click="keyboard = KEYBOARD_QWERTZ">QWERTZ</button>
                                 </div>
@@ -293,6 +294,14 @@ const KEYBOARD_AZERTY = {
         ['Entrer', 'W', 'X', 'C', 'V', 'B', 'N', 'Suppr'],
     ],
 };
+const KEYBOARD_BEPO = {
+    name: 'bepo',
+    content: [
+        ['B', 'E', 'P', 'O', 'W', 'V', 'D', 'L', 'J', 'Z'],
+        ['A', 'U', 'I', 'C', 'T', 'S', 'R', 'N', 'M'],
+        ['Entrer', 'Y', 'X', 'K', 'Q', 'G', 'H', 'F', 'Suppr'],
+    ],
+};
 const KEYBOARD_QWERTY = {
     name: 'qwerty',
     content: [
@@ -322,6 +331,7 @@ export default {
             NB_LETTERS,
             NB_ATTEMPTS,
             KEYBOARD_AZERTY,
+            KEYBOARD_BEPO,
             KEYBOARD_QWERTY,
             KEYBOARD_QWERTZ,
             keyboard: KEYBOARD_AZERTY,
@@ -1425,7 +1435,6 @@ export default {
                             .buttons
                                 background: #3A3A3C
                                 border-radius: 100px
-                                height: 25px
                                 button
                                     font-family: Outfit, Avenir, Helvetica, Arial, sans-serif
                                     height: 25px
@@ -1440,17 +1449,11 @@ export default {
                                     &.selected
                                         background: #3EAA42
                                         border-radius: 100px
-
-                                @media (max-width: 360px)
-                                    button
-                                        width: 60px
-                                        font-size: 10px
-                                @media (max-width: 330px)
-                                    height: 28px // Expend hitbox on height
-                                    button
-                                        width: 48px
-                                        height: 28px
-                                        font-size: 9px
+                            @media (max-width: 450px)
+                                .keyboard-buttons
+                                    display: flex
+                                    flex-direction: column
+                                    border-radius: 12px
                     .credits
                         h2
                             text-align: left

--- a/src/components/keyboard/Key.vue
+++ b/src/components/keyboard/Key.vue
@@ -71,7 +71,7 @@ export default {
         background: #4D4D4D
     &.big
         width: 90px
-        &.qwerty, &.qwertz
+        &.bepo, &.qwerty, &.qwertz
             width: 66px
     &.correct
         background: #3EAA42
@@ -107,13 +107,13 @@ export default {
         width: 34px
         &.big
             width: 72px
-            &.qwerty, &.qwertz
+            &.bepo, &.qwerty, &.qwertz
                 width: 53px
     @media (max-width: 393px)
         width: 32px
         &.big
             width: 68px
-            &.qwerty, &.qwertz
+            &.bepo, &.qwerty, &.qwertz
                 width: 50px
     @media (max-width: 372px)
         width: 28px
@@ -125,7 +125,7 @@ export default {
         width: 22px
         &.big
             width: 48px
-            &.qwerty, &.qwertz
+            &.bepo, &.qwerty, &.qwertz
                 width: 35px
     @media (max-height: 600px)
         height: 48px


### PR DESCRIPTION
Disposition:
![image](https://user-images.githubusercontent.com/2446451/158628421-0a787502-db14-432e-b307-4410dfb71bc3.png)

- le É a été changé en E, et le E a été supprimé de la rangée du dessous
- le W a été placé au milieu de la rangée du haut pour conserver l’alignement

Choix de la disposition avec un grand écran:
![image](https://user-images.githubusercontent.com/2446451/158627612-c4855107-b971-4165-8435-686d22174840.png)

Choix de la disposition avec un petit écran:
![image](https://user-images.githubusercontent.com/2446451/158627785-7062c8a3-8ac6-45ba-b9db-8387ca7ebf29.png)