### PR TITLE
Added import/export buttons (beta feature)

### DIFF
--- a/src/components/Game.vue
+++ b/src/components/Game.vue
@@ -390,7 +390,7 @@ export default {
         let checkBeta = () => window.location.hash.toLowerCase() === '#beta'
         this.isBetaEnabled = checkBeta()
         
-        window.addEventListener('hashchange', () => this.isBetaEnabled = checkBeta)
+        window.addEventListener('hashchange', () => this.isBetaEnabled = checkBeta())
 
         // Update timer to next word
         setInterval((function () {


### PR DESCRIPTION
From the settings modal, users will be able to export their data into a base64 string, send that string to a new device, and paste it after clicking the import button.

Since the style/design is not final and could be improved, I made sure it would only appear when the user adds "/#beta" into the URL.

I implemented a simple checksum to detect & prevent data corruption, and I also added a data structure version to make sure it won't import outdated/obsolete data from a very old version of the app.

**How to test it?**
Open the preview on two different browsers (OR one in normal browsing mode, the other in private browsing mode, OR through two different browser profiles). Make sure some data is present in the first browser, add "/#beta" into the URL, open the settings modal. Click the "Export" button, close the alert message. Go on the other browser, add "/#beta" into the URL, open the settings modal, click the "Import" button. Paste the content, close the confirm message. Tada! The grid should contain your last game, and the stats should be the same as your other session.