### PR TITLE
Ajout transition delay pour le clavier 

### DIFF
--- a/src/components/keyboard/Key.vue
+++ b/src/components/keyboard/Key.vue
@@ -1,5 +1,6 @@
 <template>
     <button id="key" @click="handleClick"
+        :style="{ transitionDelay: '1.5s'}" 
         :class="[{
             big,
             correct: color === 'correct', 
@@ -64,7 +65,7 @@ export default {
     border: none
     border-bottom: 2px solid #4D4D4D
     user-select: none
-    transition: transform 0.2s
+    transition: transform 0.1s, background 0.1s, border-bottom-color 0.1s, color 0.1s
     -webkit-tap-highlight-color: transparent
     @media (max-height: 700px)
         height: 50px


### PR DESCRIPTION
Si je joue au Wordle original, le clavier change de couleur après que toutes les lettres du mot changent. Cela crée un petit délais supplémentaire pour me dire "Est-ce-que j'ai bon?"
Dans le wordle.louan.fr actuel, ce délais n'existe pas, du coup dès que je tape "Entrer" je vois le clavier changer de couleur  et je sais immédiatement si j 'ai tord ou pas... Ça enlève un peu le mystère et le suspens (IMHO)